### PR TITLE
Add background music options to Pomodoro timer

### DIFF
--- a/src/pages/PomodoroTimer.tsx
+++ b/src/pages/PomodoroTimer.tsx
@@ -427,6 +427,31 @@ export default function PomodoroTimer() {
         </TabsContent>
       </Tabs>
 
+      {/* Music Selection */}
+      <div className="w-full max-w-sm mb-4">
+        <div className="flex items-center gap-2 mb-2">
+          <Music className="h-4 w-4" />
+          <span className="text-sm font-medium">Background Music</span>
+        </div>
+        <Select value={selectedMusic} onValueChange={setSelectedMusic}>
+          <SelectTrigger className="w-full">
+            <SelectValue placeholder="Select music type" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="none">No Music</SelectItem>
+            <SelectItem value="lofi">Lo-fi</SelectItem>
+            <SelectItem value="classical">Classical Piano</SelectItem>
+            <SelectItem value="jazz">Jazz</SelectItem>
+          </SelectContent>
+        </Select>
+        {isMusicPlaying && (
+          <p className="text-xs text-muted-foreground mt-1 flex items-center gap-1">
+            <Music className="h-3 w-3" />
+            Playing {selectedMusic} music
+          </p>
+        )}
+      </div>
+
       {/* Timer Card */}
       <Card className="w-full max-w-sm">
         <CardContent className="py-10 flex flex-col items-center">


### PR DESCRIPTION
## Purpose

Add background music functionality to the Pomodoro timer to enhance focus during study sessions. The user requested preset music options (lofi, classical piano, and jazz) that play for the entire timer duration and automatically stop when the session completes.

## Code changes

- **Music selection UI**: Added dropdown menu with Music icon for selecting background music type (none, lofi, classical piano, jazz)
- **Audio generation**: Implemented Web Audio API-based music generators for each music type using oscillators and gain nodes
- **Timer integration**: Music starts automatically when timer begins and stops when session ends or timer is paused
- **State management**: Added `selectedMusic` and `isMusicPlaying` state variables to track music status
- **Cleanup**: Proper audio context cleanup on component unmount and timer state changes
- **User feedback**: Display current playing music status below the dropdown menu

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/3677a86f79d049afa813fbef3a1794d1/quantum-world)

👀 [Preview Link](https://3677a86f79d049afa813fbef3a1794d1-quantum-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3677a86f79d049afa813fbef3a1794d1</projectId>-->
<!--<branchName>quantum-world</branchName>-->